### PR TITLE
Fix/Specify strokeWidth=2 for bars in grouped bar plot.

### DIFF
--- a/src/components/bar-plot/NewBarPlot.js
+++ b/src/components/bar-plot/NewBarPlot.js
@@ -1,11 +1,11 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-filename-extension */
 import React, { useCallback } from 'react';
-import { Bar, BarChart, Cell, Tooltip, XAxis, YAxis } from 'recharts';
+import { BarChart, Cell, Tooltip, XAxis, YAxis } from 'recharts';
 import { PLOT_COLORS, PLOT_SECONDARY_COLORS } from '../../constants/plotConstants';
 import useTooltip from '../../hooks/useTooltip';
 import getItemOpacity from '../../utils/getItemOpacity';
-
+import Bar from '../shared/bar/Bar';
 import {
   getData,
   getMargin,
@@ -45,19 +45,14 @@ function NewBarPlot({ plotConfig = {}, TooltipContent = false, isFollowUpDisable
   return (
     <PlotContainer>
       <BarChart data={data} margin={margin} onClick={onPlotClick}>
-        {GeneralChartComponents({
-          plotConfig,
-          TooltipContent,
-          tooltipHandlers,
-          tooltip,
+        {GeneralChartComponents({ plotConfig, TooltipContent, tooltipHandlers, tooltip })}
+        {Bar({
+          dataKey: yAxisDataKey,
+          name: xAxisName,
+          fill: seriesFillColor,
+          stroke: seriesStrokeColor,
           isFollowUpDisabled,
-        })}
-        <Bar
-          dataKey={yAxisDataKey}
-          name={xAxisName}
-          fill={seriesFillColor}
-          stroke={seriesStrokeColor}>
-          {data.map((item, index) => {
+          children: data.map((item) => {
             const itemOpacity = getItemOpacity({ id: item.id, hoveredItemId, clickedItemId });
             return (
               <Cell
@@ -69,8 +64,8 @@ function NewBarPlot({ plotConfig = {}, TooltipContent = false, isFollowUpDisable
                 strokeWidth={2}
               />
             );
-          })}
-        </Bar>
+          }),
+        })}
       </BarChart>
     </PlotContainer>
   );

--- a/src/components/bar-plot/NewBarPlot.js
+++ b/src/components/bar-plot/NewBarPlot.js
@@ -2,7 +2,6 @@
 /* eslint-disable react/jsx-filename-extension */
 import React, { useCallback } from 'react';
 import { BarChart, Cell, Tooltip, XAxis, YAxis } from 'recharts';
-import { PLOT_COLORS, PLOT_SECONDARY_COLORS } from '../../constants/plotConstants';
 import useTooltip from '../../hooks/useTooltip';
 import getItemOpacity from '../../utils/getItemOpacity';
 import Bar from '../shared/bar/Bar';
@@ -45,13 +44,19 @@ function NewBarPlot({ plotConfig = {}, TooltipContent = false, isFollowUpDisable
   return (
     <PlotContainer>
       <BarChart data={data} margin={margin} onClick={onPlotClick}>
-        {GeneralChartComponents({ plotConfig, TooltipContent, tooltipHandlers, tooltip })}
+        {GeneralChartComponents({
+          plotConfig,
+          TooltipContent,
+          tooltipHandlers,
+          tooltip,
+          isFollowUpDisabled,
+        })}
         {Bar({
           dataKey: yAxisDataKey,
           name: xAxisName,
           fill: seriesFillColor,
           stroke: seriesStrokeColor,
-          isFollowUpDisabled,
+
           children: data.map((item) => {
             const itemOpacity = getItemOpacity({ id: item.id, hoveredItemId, clickedItemId });
             return (

--- a/src/components/bar-plot/NewBarPlot.js
+++ b/src/components/bar-plot/NewBarPlot.js
@@ -17,6 +17,7 @@ import {
 } from '../../utils/plotConfigGetters';
 import GeneralChartComponents from '../general-chart-components/GeneralChartComponents';
 import PlotContainer from '../plot-container/PlotContainer';
+import { BAR_STROKE_WIDTH } from '../../constants/plotConstants';
 
 function NewBarPlot({ plotConfig = {}, TooltipContent = false, isFollowUpDisabled = false }) {
   const yAxisDataKey = getYAxisDataKey(plotConfig);
@@ -56,7 +57,7 @@ function NewBarPlot({ plotConfig = {}, TooltipContent = false, isFollowUpDisable
           name: xAxisName,
           fill: seriesFillColor,
           stroke: seriesStrokeColor,
-
+          strokeWidth: BAR_STROKE_WIDTH,
           children: data.map((item) => {
             const itemOpacity = getItemOpacity({ id: item.id, hoveredItemId, clickedItemId });
             return (

--- a/src/components/funnel-bar-plot/NewFunnelBarPlot.js
+++ b/src/components/funnel-bar-plot/NewFunnelBarPlot.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-filename-extension */
-import React, { useCallback } from 'react';
-// TODO: NJM Here
-import { Bar, BarChart, LabelList } from 'recharts';
+import React from 'react';
+import { BarChart, LabelList } from 'recharts';
+import Bar from '../shared/bar/Bar';
 import colors from '../../constants/colors';
 import fontSizes from '../../constants/fontSizes';
 import fontWeights from '../../constants/fontWeights';
@@ -32,37 +32,39 @@ function PivotedFunnelBarPlot({ plotConfig, updateHoveredItemId }) {
     const droppedOffDataKey = `DROPPED_OFF_${categoryName}`;
     return (
       <>
-        <Bar
-          id={droppedOffDataKey}
-          isAnimationActive={false}
-          stackId={categoryName}
-          dataKey={droppedOffDataKey}
-          name={`Dropped Off - ${categoryName}`}
-          stroke={PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length]}
-          fill={PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length]}
-          onMouseOver={() => updateHoveredItemId(convertedDataKey)}
-          onMouseLeave={() => updateHoveredItemId(null)}
-        />
-        <Bar
-          id={convertedDataKey}
-          isAnimationActive={false}
-          stackId={categoryName}
-          dataKey={convertedDataKey}
-          name={`Converted - ${categoryName}`}
-          stroke={PLOT_COLORS[index % PLOT_COLORS.length]}
-          fill={PLOT_COLORS[index % PLOT_COLORS.length]}
-          onMouseOver={() => updateHoveredItemId(droppedOffDataKey)}
-          onMouseLeave={() => updateHoveredItemId(null)}>
-          <LabelList
-            offset={16}
-            dataKey={convertedDataKey}
-            position="top"
-            fill={colors.gray[500]}
-            fontWeight={fontWeights.medium}
-            fontSize={fontSizes.xs}
-            formatter={yAxisTickFormatter}
-          />
-        </Bar>
+        {Bar({
+          id: droppedOffDataKey,
+          isAnimationActive: false,
+          stackId: categoryName,
+          dataKey: droppedOffDataKey,
+          name: `Dropped Off - ${categoryName}`,
+          stroke: PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length],
+          fill: PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length],
+          onMouseOver: () => updateHoveredItemId(convertedDataKey),
+          onMouseLeave: () => updateHoveredItemId(null),
+        })}
+        {Bar({
+          id: convertedDataKey,
+          isAnimationActive: false,
+          stackId: categoryName,
+          dataKey: convertedDataKey,
+          name: `Converted - ${categoryName}`,
+          stroke: PLOT_COLORS[index % PLOT_COLORS.length],
+          fill: PLOT_COLORS[index % PLOT_COLORS.length],
+          onMouseOver: () => updateHoveredItemId(droppedOffDataKey),
+          onMouseLeave: () => updateHoveredItemId(null),
+          children: (
+            <LabelList
+              offset={16}
+              dataKey={convertedDataKey}
+              position="top"
+              fill={colors.gray[500]}
+              fontWeight={fontWeights.medium}
+              fontSize={fontSizes.xs}
+              formatter={yAxisTickFormatter}
+            />
+          ),
+        })}
       </>
     );
   });
@@ -74,37 +76,39 @@ function NonPivotedFunnelBarPlot({ plotConfig, updateHoveredItemId, hoveredItemI
   const yAxisTickFormatter = getYAxisTickFormatter(plotConfig);
   return (
     <>
-      <Bar
-        isAnimationActive={false}
-        id="DROPPED_OFF"
-        name={'Dropped Off'}
-        dataKey={'DROPPED_OFF'}
-        fill={seriesFillColor}
-        stackId="a"
-        radius={[3, 3, 0, 0]}
-        onMouseOver={() => updateHoveredItemId('DROPPED_OFF')}
-        onMouseLeave={() => updateHoveredItemId(null)}
-      />
-      <Bar
-        isAnimationActive={false}
-        id="CONVERTED"
-        name={'Converted'}
-        dataKey={'CONVERTED'}
-        fill={seriesStrokeColor}
-        stackId="a"
-        radius={[3, 3, 0, 0]}
-        onMouseOver={() => updateHoveredItemId('CONVERTED')}
-        onMouseLeave={() => updateHoveredItemId(null)}>
-        <LabelList
-          offset={16}
-          dataKey="CONVERTED"
-          position="top"
-          fill={colors.gray[500]}
-          fontWeight={fontWeights.medium}
-          fontSize={fontSizes.xs}
-          formatter={yAxisTickFormatter}
-        />
-      </Bar>
+      {Bar({
+        isAnimationActive: false,
+        id: 'DROPPED_OFF',
+        name: 'Dropped Off',
+        dataKey: 'DROPPED_OFF',
+        fill: seriesFillColor,
+        stackId: 'a',
+        radius: [3, 3, 0, 0],
+        onMouseOver: () => updateHoveredItemId('DROPPED_OFF'),
+        onMouseLeave: () => updateHoveredItemId(null),
+      })}
+      {Bar({
+        isAnimationActive: false,
+        id: 'CONVERTED',
+        name: 'Converted',
+        dataKey: 'CONVERTED',
+        fill: seriesStrokeColor,
+        stackId: 'a',
+        radius: [3, 3, 0, 0],
+        onMouseOver: () => updateHoveredItemId('CONVERTED'),
+        onMouseLeave: () => updateHoveredItemId(null),
+        children: (
+          <LabelList
+            offset={16}
+            dataKey="CONVERTED"
+            position="top"
+            fill={colors.gray[500]}
+            fontWeight={fontWeights.medium}
+            fontSize={fontSizes.xs}
+            formatter={yAxisTickFormatter}
+          />
+        ),
+      })}
     </>
   );
 }

--- a/src/components/funnel-bar-plot/NewFunnelBarPlot.js
+++ b/src/components/funnel-bar-plot/NewFunnelBarPlot.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-filename-extension */
 import React, { useCallback } from 'react';
+// TODO: NJM Here
 import { Bar, BarChart, LabelList } from 'recharts';
 import colors from '../../constants/colors';
 import fontSizes from '../../constants/fontSizes';

--- a/src/components/grouped-bar-plot/NewGroupedBarPlot.js
+++ b/src/components/grouped-bar-plot/NewGroupedBarPlot.js
@@ -1,7 +1,8 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
-import { Bar, BarChart } from 'recharts';
+import { BarChart } from 'recharts';
+import Bar from '../shared/bar/Bar';
 import { PLOT_COLORS, PLOT_SECONDARY_COLORS } from '../../constants/plotConstants';
 import useTooltip from '../../hooks/useTooltip';
 import { v4 as uuidv4 } from 'uuid';
@@ -26,22 +27,20 @@ function PivotedGroupedBar({
   const data = getData(plotConfig);
   const yAxisDataKey = getYAxisDataKey(plotConfig);
   return data.map((series, index) => {
-    return (
-      <Bar
-        id={series.name}
-        data={series.data}
-        stroke={PLOT_COLORS[index % PLOT_COLORS.length]}
-        fill={PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length]}
-        dataKey={yAxisDataKey}
-        name={series.name}
-        key={series.name}
-        fillOpacity={!hoveredItemId || hoveredItemId === series.name ? 1 : 0.2}
-        strokeOpacity={!hoveredItemId || hoveredItemId === series.name ? 1 : 0.2}
-        onMouseOver={() => updateHoveredItemId(series.name)}
-        onMouseLeave={() => updateHoveredItemId(null)}
-        onClick={(e) => updateClickedItemId(series.name, e?.tooltipPosition)}
-      />
-    );
+    return Bar({
+      id: series.name,
+      data: series.data,
+      stroke: PLOT_COLORS[index % PLOT_COLORS.length],
+      fill: PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length],
+      dataKey: yAxisDataKey,
+      name: series.name,
+      key: series.name,
+      fillOpacity: !hoveredItemId || hoveredItemId === series.name ? 1 : 0.2,
+      strokeOpacity: !hoveredItemId || hoveredItemId === series.name ? 1 : 0.2,
+      onMouseOver: () => updateHoveredItemId(series.name),
+      onMouseLeave: () => updateHoveredItemId(null),
+      onClick: (e) => updateClickedItemId(series.name, e?.tooltipPosition),
+    });
   });
 }
 
@@ -53,17 +52,14 @@ function NonPivotedGroupedBar({
   const categoryValueAxes = getCategoryValueAxes(plotConfig);
   const isSeriesStacked = getIsSeriesStacked(plotConfig);
   return categoryValueAxes.map((axes, index) => {
-    return (
-      <Bar
-        dataKey={axes.dataKey}
-        name={axes.name}
-        fill={PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length]}
-        stroke={PLOT_COLORS[index % PLOT_COLORS.length]}
-        stackId={isSeriesStacked ? 'a' : undefined}
-        // onMouseOver={() => updateHoveredItemId(series.name)}
-        onMouseLeave={() => updateHoveredItemId(null)}
-      />
-    );
+    return Bar({
+      dataKey: axes.dataKey,
+      name: axes.name,
+      fill: PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length],
+      stroke: PLOT_COLORS[index % PLOT_COLORS.length],
+      stackId: isSeriesStacked ? 'a' : undefined,
+      onMouseLeave: () => updateHoveredItemId(null),
+    });
   });
 }
 

--- a/src/components/grouped-bar-plot/NewGroupedBarPlot.js
+++ b/src/components/grouped-bar-plot/NewGroupedBarPlot.js
@@ -3,7 +3,11 @@
 import React from 'react';
 import { BarChart } from 'recharts';
 import Bar from '../shared/bar/Bar';
-import { PLOT_COLORS, PLOT_SECONDARY_COLORS } from '../../constants/plotConstants';
+import {
+  BAR_STROKE_WIDTH,
+  PLOT_COLORS,
+  PLOT_SECONDARY_COLORS,
+} from '../../constants/plotConstants';
 import useTooltip from '../../hooks/useTooltip';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -37,6 +41,7 @@ function PivotedGroupedBar({
       key: series.name,
       fillOpacity: !hoveredItemId || hoveredItemId === series.name ? 1 : 0.2,
       strokeOpacity: !hoveredItemId || hoveredItemId === series.name ? 1 : 0.2,
+      strokeWidth: BAR_STROKE_WIDTH,
       onMouseOver: () => updateHoveredItemId(series.name),
       onMouseLeave: () => updateHoveredItemId(null),
       onClick: (e) => updateClickedItemId(series.name, e?.tooltipPosition),
@@ -58,6 +63,7 @@ function NonPivotedGroupedBar({
       fill: PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length],
       stroke: PLOT_COLORS[index % PLOT_COLORS.length],
       stackId: isSeriesStacked ? 'a' : undefined,
+      strokeWidth: BAR_STROKE_WIDTH,
       onMouseLeave: () => updateHoveredItemId(null),
     });
   });

--- a/src/components/histogram-plot/NewHistogramPlot.js
+++ b/src/components/histogram-plot/NewHistogramPlot.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
-// TODO: NJM Here
-import { Bar, BarChart, Tooltip, XAxis, YAxis } from 'recharts';
+import { BarChart, Tooltip, XAxis, YAxis } from 'recharts';
+import Bar from '../shared/bar/Bar';
 import useBrush from '../../hooks/useBrush';
 import useTooltip from '../../hooks/useTooltip';
 
@@ -84,8 +84,12 @@ function NewHistogramPlot({
           },
           customLabelFormatter,
         })}
-
-        <Bar dataKey="value" fill={seriesFillColor} stroke={seriesStrokeColor} name="Frequency" />
+        {Bar({
+          dataKey: 'value',
+          fill: seriesFillColor,
+          stroke: seriesStrokeColor,
+          name: 'Frequency',
+        })}
       </BarChart>
     </PlotContainer>
   );

--- a/src/components/histogram-plot/NewHistogramPlot.js
+++ b/src/components/histogram-plot/NewHistogramPlot.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
+// TODO: NJM Here
 import { Bar, BarChart, Tooltip, XAxis, YAxis } from 'recharts';
 import useBrush from '../../hooks/useBrush';
 import useTooltip from '../../hooks/useTooltip';

--- a/src/components/shared/bar/Bar.js
+++ b/src/components/shared/bar/Bar.js
@@ -1,0 +1,10 @@
+/* eslint-disable react/jsx-props-no-spreading */
+/* eslint-disable react/jsx-filename-extension */
+import React from 'react';
+import { Bar as RechartsBar } from 'recharts';
+
+function Bar(props) {
+  return <RechartsBar strokeWidth={2} {...props} />;
+}
+
+export default Bar;

--- a/src/components/shared/bar/Bar.js
+++ b/src/components/shared/bar/Bar.js
@@ -14,11 +14,12 @@ function Bar({
   key,
   fillOpacity,
   strokeOpacity,
+  isAnimationActive = false,
   onMouseOver = () => {},
   onMouseLeave = () => {},
   onClick = () => {},
   stackId,
-  strokeWidth = 2,
+  strokeWidth,
 }) {
   return (
     <RechartsBar
@@ -35,6 +36,7 @@ function Bar({
       onMouseLeave={onMouseLeave}
       onClick={onClick}
       stackId={stackId}
+      isAnimationActive={isAnimationActive}
       strokeWidth={strokeWidth}>
       {children}
     </RechartsBar>

--- a/src/components/shared/bar/Bar.js
+++ b/src/components/shared/bar/Bar.js
@@ -1,10 +1,44 @@
-/* eslint-disable react/jsx-props-no-spreading */
+/* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
 import { Bar as RechartsBar } from 'recharts';
 
-function Bar(props) {
-  return <RechartsBar strokeWidth={2} {...props} />;
+function Bar({
+  dataKey,
+  name,
+  fill,
+  stroke,
+  children,
+  id,
+  data,
+  key,
+  fillOpacity,
+  strokeOpacity,
+  onMouseOver = () => {},
+  onMouseLeave = () => {},
+  onClick = () => {},
+  stackId,
+  strokeWidth = 2,
+}) {
+  return (
+    <RechartsBar
+      dataKey={dataKey}
+      name={name}
+      fill={fill}
+      stroke={stroke}
+      id={id}
+      data={data}
+      key={key}
+      fillOpacity={fillOpacity}
+      strokeOpacity={strokeOpacity}
+      onMouseOver={onMouseOver}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+      stackId={stackId}
+      strokeWidth={strokeWidth}>
+      {children}
+    </RechartsBar>
+  );
 }
 
 export default Bar;

--- a/src/components/waterfall-plot/NewWaterfallPlot.js
+++ b/src/components/waterfall-plot/NewWaterfallPlot.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-filename-extension */
 import React, { useCallback } from 'react';
-// TODO: NJM Here
-import { Bar, BarChart, Cell, LabelList } from 'recharts';
+import { BarChart, Cell, LabelList } from 'recharts';
+import Bar from '../shared/bar/Bar';
 import fontSizes from '../../constants/fontSizes';
 import fontWeights from '../../constants/fontWeights';
 import {
@@ -96,25 +96,31 @@ function NewWaterfallPlot({ plotConfig = {}, TooltipContent = false, isFollowUpD
             },
           },
         })}
-        <Bar dataKey={yAxisDataKey} isAnimationActive={false}>
-          <LabelList
-            dataKey={yAxisDataKey}
-            content={(props) => renderCustomizedLabel(props, yAxisTickFormatter)}
-          />
-          {data.map((item, index) => {
-            const itemOpacity = getItemOpacity({ id: item.id, hoveredItemId, clickedItemId });
-            return (
-              <Cell
-                key={item.id}
-                fill={PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length]}
-                stroke={PLOT_COLORS[index % PLOT_COLORS.length]}
-                fillOpacity={itemOpacity}
-                strokeOpacity={itemOpacity}
-                strokeWidth={2}
+        {Bar({
+          dataKey: yAxisDataKey,
+          isAnimationActive: false,
+          children: (
+            <>
+              <LabelList
+                dataKey={yAxisDataKey}
+                content={(props) => renderCustomizedLabel(props, yAxisTickFormatter)}
               />
-            );
-          })}
-        </Bar>
+              {data.map((item, index) => {
+                const itemOpacity = getItemOpacity({ id: item.id, hoveredItemId, clickedItemId });
+                return (
+                  <Cell
+                    key={item.id}
+                    fill={PLOT_SECONDARY_COLORS[index % PLOT_SECONDARY_COLORS.length]}
+                    stroke={PLOT_COLORS[index % PLOT_COLORS.length]}
+                    fillOpacity={itemOpacity}
+                    strokeOpacity={itemOpacity}
+                    strokeWidth={2}
+                  />
+                );
+              })}
+            </>
+          ),
+        })}
       </BarChart>
     </PlotContainer>
   );

--- a/src/components/waterfall-plot/NewWaterfallPlot.js
+++ b/src/components/waterfall-plot/NewWaterfallPlot.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-filename-extension */
 import React, { useCallback } from 'react';
+// TODO: NJM Here
 import { Bar, BarChart, Cell, LabelList } from 'recharts';
 import fontSizes from '../../constants/fontSizes';
 import fontWeights from '../../constants/fontWeights';

--- a/src/constants/plotConstants.js
+++ b/src/constants/plotConstants.js
@@ -129,3 +129,5 @@ export const AXIS_DATA_KEY_KEYS = {
   CATEGORY_AXIS_DATA_KEY_KEY: 'categoryDataKey',
   CATEGORY_VALUE_DATA_KEYS_KEY: 'categoryValueDataKeys',
 };
+
+export const BAR_STROKE_WIDTH = 2;


### PR DESCRIPTION
- Create a shared Bar component with a default strokeWidth of 2
- Swap it in for GroupedBarPlot and BarPlot

Before:
![image](https://user-images.githubusercontent.com/72046909/201778904-269507e7-1d27-44c5-81cf-a9a3bcd16362.png)

After:
![image](https://user-images.githubusercontent.com/72046909/201778953-e7470215-fc68-41c3-bbc1-d12168ee686f.png)
