### PR TITLE
Fix/Pass isFollowUpDisabled to GeneralComponents from new plots that did …

### DIFF
--- a/src/components/bar-plot/NewBarPlot.js
+++ b/src/components/bar-plot/NewBarPlot.js
@@ -19,7 +19,7 @@ import {
 import GeneralChartComponents from '../general-chart-components/GeneralChartComponents';
 import PlotContainer from '../plot-container/PlotContainer';
 
-function NewBarPlot({ plotConfig = {}, TooltipContent = false }) {
+function NewBarPlot({ plotConfig = {}, TooltipContent = false, isFollowUpDisabled = false }) {
   const yAxisDataKey = getYAxisDataKey(plotConfig);
   const xAxisName = getXAxisName(plotConfig);
 
@@ -45,7 +45,13 @@ function NewBarPlot({ plotConfig = {}, TooltipContent = false }) {
   return (
     <PlotContainer>
       <BarChart data={data} margin={margin} onClick={onPlotClick}>
-        {GeneralChartComponents({ plotConfig, TooltipContent, tooltipHandlers, tooltip })}
+        {GeneralChartComponents({
+          plotConfig,
+          TooltipContent,
+          tooltipHandlers,
+          tooltip,
+          isFollowUpDisabled,
+        })}
         <Bar
           dataKey={yAxisDataKey}
           name={xAxisName}

--- a/src/components/funnel-bar-plot/NewFunnelBarPlot.js
+++ b/src/components/funnel-bar-plot/NewFunnelBarPlot.js
@@ -108,7 +108,7 @@ function NonPivotedFunnelBarPlot({ plotConfig, updateHoveredItemId, hoveredItemI
   );
 }
 
-function FunnelBarPlot({ plotConfig = {}, TooltipContent = false }) {
+function FunnelBarPlot({ plotConfig = {}, TooltipContent = false, isFollowUpDisabled = false }) {
   const data = getData(plotConfig);
   const margin = getMargin(plotConfig);
 
@@ -133,6 +133,7 @@ function FunnelBarPlot({ plotConfig = {}, TooltipContent = false }) {
           TooltipContent,
           tooltipHandlers,
           tooltip,
+          isFollowUpDisabled,
           customValueFormatter: yAxisTickFormatter,
         })}
         {isDataPivoted && PivotedFunnelBarPlot({ plotConfig, updateHoveredItemId })}

--- a/src/components/grouped-bar-plot/NewGroupedBarPlot.js
+++ b/src/components/grouped-bar-plot/NewGroupedBarPlot.js
@@ -67,7 +67,7 @@ function NonPivotedGroupedBar({
   });
 }
 
-function NewGroupedBar({ plotConfig = {}, TooltipContent = false }) {
+function NewGroupedBar({ plotConfig = {}, TooltipContent = false, isFollowUpDisabled = false }) {
   const data = getData(plotConfig);
   const margin = getMargin(plotConfig);
   const isDataPivoted = getIsDataPivoted(plotConfig);
@@ -86,6 +86,7 @@ function NewGroupedBar({ plotConfig = {}, TooltipContent = false }) {
           tooltip,
           tooltipHandlers,
           legendConfig: { useStrokeColorShape: true, iconType: 'square' },
+          isFollowUpDisabled,
         })}
         {isDataPivoted &&
           PivotedGroupedBar({

--- a/src/components/sankey-plot/NewSankeyPlot.js
+++ b/src/components/sankey-plot/NewSankeyPlot.js
@@ -17,7 +17,7 @@ import PlotContainer from '../plot-container/PlotContainer';
 import SankeyPlotLink from './components/sankey-plot-link/SankeyPlotLink';
 import SankeyPlotNode from './components/sankey-plot-node/SankeyPlotNode';
 
-function NewSankeyPlot({ plotConfig = {}, TooltipContent = () => {} }) {
+function NewSankeyPlot({ plotConfig = {}, TooltipContent = () => {}, isFollowUpDisabled = false }) {
   const data = getData(plotConfig);
   const margin = getMargin(plotConfig);
 
@@ -66,6 +66,7 @@ function NewSankeyPlot({ plotConfig = {}, TooltipContent = () => {} }) {
           TooltipContent,
           useGridLines: false,
           customValueFormatter,
+          isFollowUpDisabled,
         })}
       </Sankey>
     </PlotContainer>

--- a/src/components/waterfall-plot/NewWaterfallPlot.js
+++ b/src/components/waterfall-plot/NewWaterfallPlot.js
@@ -52,7 +52,7 @@ const renderCustomizedLabel = (props, yAxisTickFormatter) => {
   );
 };
 
-function NewWaterfallPlot({ plotConfig = {}, TooltipContent = false }) {
+function NewWaterfallPlot({ plotConfig = {}, TooltipContent = false, isFollowUpDisabled = false }) {
   const yAxisDataKey = getYAxisDataKey(plotConfig);
   const yAxisTickFormatter = getYAxisTickFormatter(plotConfig);
 
@@ -82,6 +82,7 @@ function NewWaterfallPlot({ plotConfig = {}, TooltipContent = false }) {
           TooltipContent,
           tooltipHandlers,
           tooltip,
+          isFollowUpDisabled,
           xAxisConfig: {
             ...xAxisConfig,
             tickLine: false,


### PR DESCRIPTION
- Pass `isFollowUpDisabled` prop from components like `NewBarPlot` to `GeneralChartComponents`

Before:
![image](https://user-images.githubusercontent.com/72046909/201969151-4b1bc95d-bf30-4792-b6b6-3be9bf10828a.png)

After (I'm clicking around trying to trigger it but am unable to):
![image](https://user-images.githubusercontent.com/72046909/201969259-0d840ed7-8f79-4c68-9754-e140d1f75f00.png)

And question-level plots still allow follow up:
![image](https://user-images.githubusercontent.com/72046909/201970380-a9c8adbd-128f-4461-a8de-4ace686e31ee.png)
